### PR TITLE
fix: Correct publish path in netlify.toml

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -10,8 +10,8 @@
   command = "npm run build"
 
   # Publish directory: The directory containing the built static assets.
-  # Vite's default output directory is "dist".
-  publish = "frontend/dist/"
+  # Vite's default output directory is "dist". This is relative to the 'base' directory.
+  publish = "dist/"
 
 # Settings for the development environment (netlify dev)
 [dev]


### PR DESCRIPTION
### **User description**
The publish directory in `netlify.toml` was previously set to `frontend/dist/`. Since the `base` directory is `frontend/`, Netlify was incorrectly looking for `frontend/frontend/dist/`.

This commit changes the `publish` directory to `dist/`, which is the correct path relative to the `frontend/` base directory.


___

### **PR Type**
Bug fix


___

### **Description**
- Fix incorrect publish path in `netlify.toml` configuration

- Correct path from `frontend/dist/` to `dist/` relative to base directory


___

### **Changes diagram**

```mermaid
flowchart LR
  A["netlify.toml"] --> B["base: frontend/"]
  B --> C["publish: frontend/dist/"]
  C --> D["publish: dist/"]
  D --> E["Correct deployment path"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>netlify.toml</strong><dd><code>Fix publish path configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

netlify.toml

<li>Changed publish directory from <code>frontend/dist/</code> to <code>dist/</code><br> <li> Updated comment to clarify path is relative to base directory


</details>


  </td>
  <td><a href="https://github.com/yethikrishna/yeti-ai/pull/2/files#diff-ab8f79b68b7adff7a07db953bf453f3c5aa6ade98d2b1b67d8432b36392489ed">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>